### PR TITLE
[FIX] Fetching cover images from cloudinary

### DIFF
--- a/src/components/projects/ContractCardV2.tsx
+++ b/src/components/projects/ContractCardV2.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Contract } from '../../model/types'
 import { Link } from 'react-router-dom'
-import { getContractCover } from '../../utils/retrieve'
+import { getContractCoverThumbnail } from '../../utils/retrieve'
 
 const ContractCardV2: React.FC<{ contract: Contract}> = ({contract}) => {
     const [CoverImage, setCoverImage] = useState<string>();
@@ -9,7 +9,7 @@ const ContractCardV2: React.FC<{ contract: Contract}> = ({contract}) => {
     useEffect(() => {
         async function getCover() {
             try {
-                const data = await getContractCover(contract.name)
+                const data = await getContractCoverThumbnail(contract.name)
                 setCoverImage(data);
             } catch {
                 console.log("error getting cover")

--- a/src/utils/retrieve.ts
+++ b/src/utils/retrieve.ts
@@ -87,30 +87,34 @@ export const getResourceType = async (contract: string) => {
       });
     });
 };
-
 export const getContractCover = async (contract: string) => {
   // console.log("Getting contract cover for " + contract);
   const request_data = {
     collection: contract,
   };
-  const res = await apiClient
-    .get(API_PATHS.CLAIM_COVER, { params: request_data, responseType: 'blob' })
+  return apiClient
+  .get(API_PATHS.CLAIM_COVER, { params: request_data })
+  .then(function (res) {
+    return Promise.resolve(res.data.cover_cdn_url);
+  })
+  .catch(function (error) {
+    return Promise.reject("Error getting cover thumbnail")
+  });
+};
+
+export const getContractCoverThumbnail = async (contract: string) => {
+  // console.log("Getting contract cover for " + contract);
+  const request_data = {
+    collection: contract,
+  };
+  return apiClient
+    .get(API_PATHS.CLAIM_COVER, { params: request_data })
     .then(function (res) {
-      if (res.status === 200) {
-        return res.data;
-      } else {
-        throw new Error(res.statusText);
-      }
+      return Promise.resolve(res.data.cover_cdn_thumbnail_url);
     })
     .catch(function (error) {
-      console.log(error);
+      return Promise.reject("Error getting cover thumbnail")
     });
-
-  if (res) {
-    return Promise.resolve(URL.createObjectURL(res));
-  } else {
-    return Promise.reject('error');
-  }
 };
 
 export const getContractAudioSamples = async (contract: string) => {


### PR DESCRIPTION
- Cover images are fetched from cloudinary URL returned by backend
- Project page cards use cloudinary thumbnails, not full sized cover images